### PR TITLE
Fix number_index value on split

### DIFF
--- a/src/Api/Commands/SplitDiscussionHandler.php
+++ b/src/Api/Commands/SplitDiscussionHandler.php
@@ -106,7 +106,7 @@ class SplitDiscussionHandler
      *
      * @param Discussion $originalDiscussion
      * @param Discussion $discussion
-     * @param            $start_post_id
+     * @param            $start_post_number
      * @param            $end_post_number
      * @return \Illuminate\Database\Eloquent\Collection
      */
@@ -117,14 +117,14 @@ class SplitDiscussionHandler
             ->where('discussion_id', $originalDiscussion->id)
             ->whereBetween('number', [$start_post_number, $end_post_number])
             ->update(['discussion_id' => $discussion->id]);
-            
+
         $this->posts
             ->query()
             ->where('discussion_id', $discussion->id)
             ->orderBy('number', 'ASC')
             ->decrement('number', $start_post_number - 1);
 
-        $discussion->number_index = ($end_post_number - $start_post_number - 1);
+        $discussion->number_index = $end_post_number - ($start_post_number - 1);
         $discussion->save();
         
         // Update relationship posts on new discussion.


### PR DESCRIPTION
After splitting a discussion, trying to change tags or post comments fails with an `Integrity constraint violation` SQL error. This is due to an invalid  `number_index` value.

Trying again a few times usually solves the error because the  `number_index` is incremented each time, until it has a valid value again.

The issue is worst on Flarum Discuss because integrity checks do not seem to be enabled. Posts get duplicate numbers and it causes issues like [read status](https://discuss.flarum.org/d/5283-scroll-to-bottom-does-not-mark-as-read).

When splitting, `number_index` value is off by two, which result in Flarum trying to re-assign post numbers. This PR fixes the calculation for `number_index`.